### PR TITLE
docs: removing `optional` identifier in arguments type definitions for the run function docstring

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/hugobyte/polkadot-kurtosis-package"
+name: "github.com/leoporoli/polkadot-kurtosis-package"

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/leoporoli/polkadot-kurtosis-package"
+name: "github.com/hugobyte/polkadot-kurtosis-package"

--- a/main.star
+++ b/main.star
@@ -13,19 +13,19 @@ def run(plan, chain_type = "local", relaychain = None, parachains = None, explor
     
     Args:
         chain_type (string): The type of chain (local, testnet or mainnet). Default is local.
-        relaychain (json, optional): A json object containing data for relay chain config.
+        relaychain (json): A json object containing data for relay chain config.
             - name (string): Name of relay chain.
             - nodes (json): A json object containing node details.
                 - name (string): Name of node.
                 - node_type (string): Type of node.
                 - prometheus (bool): Boolean value to enable metrics for a given node.
-        parachains (json, optional): A json object containing data for para chain config. Each item in the list has the following:
+        parachains (json): A json object containing data for para chain config. Each item in the list has the following:
             - name (string): Name of para chain.
             - nodes (json): A json object containing node details.
                 - name (string): Name of node.
                 - node_type (string): Type of node.
                 - prometheus (bool): Boolean value to enable metrics for a given node.
-        explorer (bool, optional): A boolean value indicating whether to enable polkadot js explorer or not.
+        explorer (bool): A boolean value indicating whether to enable polkadot js explorer or not.
 
     Returns:
         service_details (json): Service details containing information about relay chains, parachains, and Prometheus.


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
